### PR TITLE
Add state-specific icons for binary sensors

### DIFF
--- a/custom_components/keba_heat_pump_modbus/binary_sensor.py
+++ b/custom_components/keba_heat_pump_modbus/binary_sensor.py
@@ -48,7 +48,6 @@ class KebaBinarySensor(CoordinatorEntity[KebaCoordinator], BinarySensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_{reg.unique_id}"
         self._attr_name = reg.name
 
-        self._attr_icon = reg.icon
         self._attr_device_class = reg.device_class
         self._attr_entity_category = reg.entity_category
         self._attr_entity_registry_enabled_default = reg.enabled_default
@@ -74,3 +73,12 @@ class KebaBinarySensor(CoordinatorEntity[KebaCoordinator], BinarySensorEntity):
             return None
         value = self.coordinator.data.get(self._reg.unique_id)
         return bool(value) if value is not None else None
+
+    @property
+    def icon(self) -> str | None:
+        state = self.is_on
+        if state is True and self._reg.icon_on:
+            return self._reg.icon_on
+        if state is False and self._reg.icon_off:
+            return self._reg.icon_off
+        return self._reg.icon

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/buffer_tank.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/buffer_tank.json
@@ -72,6 +72,8 @@
       "data_type": "boolean",
       "device": "buffer_tank",
       "icon": "mdi:fire",
+      "icon_on": "mdi:fire",
+      "icon_off": "mdi:fire-off",
       "device_class": "boolean",
       "state_class": "measurement",
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_1.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_1.json
@@ -282,6 +282,8 @@
       "data_type": "int16",
       "device": "circuit_1",
       "icon": "mdi:pump",
+      "icon_on": "mdi:pump",
+      "icon_off": "mdi:pump-off",
       "device_class": null,
       "state_class": null,
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_2.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_2.json
@@ -286,6 +286,8 @@
       "data_type": "int16",
       "device": "circuit_2",
       "icon": "mdi:pump",
+      "icon_on": "mdi:pump",
+      "icon_off": "mdi:pump-off",
       "device_class": null,
       "state_class": null,
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_3.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_3.json
@@ -286,6 +286,8 @@
       "data_type": "int16",
       "device": "circuit_3",
       "icon": "mdi:pump",
+      "icon_on": "mdi:pump",
+      "icon_off": "mdi:pump-off",
       "device_class": null,
       "state_class": null,
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_4.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/circuit_4.json
@@ -286,6 +286,8 @@
       "data_type": "int16",
       "device": "circuit_4",
       "icon": "mdi:pump",
+      "icon_on": "mdi:pump",
+      "icon_off": "mdi:pump-off",
       "device_class": null,
       "state_class": null,
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/modbus_registers/dhw_tank.json
+++ b/custom_components/keba_heat_pump_modbus/modbus_registers/dhw_tank.json
@@ -74,6 +74,8 @@
       "data_type": "boolean",
       "device": "dhw_tank",
       "icon": "mdi:fire",
+      "icon_on": "mdi:fire",
+      "icon_off": "mdi:fire-off",
       "device_class": "boolean",
       "state_class": "measurement",
       "entity_category": null,

--- a/custom_components/keba_heat_pump_modbus/models.py
+++ b/custom_components/keba_heat_pump_modbus/models.py
@@ -22,6 +22,8 @@ class ModbusRegister:
     precision: int | None = None
     device: str = "heat_pump"  # logical device group (heat_pump, dhw_tank, buffer_tank, circuit_1, ...)
     icon: str | None = None
+    icon_on: str | None = None
+    icon_off: str | None = None
     device_class: str | None = None
     state_class: str | None = None
     entity_category: str | None = None  # "diagnostic", "config", etc.


### PR DESCRIPTION
## Summary
- add support for per-state icons on binary sensors
- define on/off icons for all existing binary sensor register definitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ea019a7d0832391d5f44925083a73)