### PR TITLE
Add pytest coverage config and expand test coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=custom_components/keba_heat_pump_modbus --cov-report=term-missing

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,42 @@
+from custom_components.keba_heat_pump_modbus.climate import _collect_circuit_registers
+from custom_components.keba_heat_pump_modbus.models import ModbusRegister
+
+
+def test_collect_circuit_registers_ignores_reduced_setpoint():
+    registers = [
+        ModbusRegister(
+            unique_id="actual_room_temperature_circuit_1",
+            name="Actual Room Temperature",
+            register_type="input",
+            address=1,
+            device="circuit_1",
+        ),
+        ModbusRegister(
+            unique_id="room_set_temperature_reduced_circuit_1",
+            name="Reduced Room Set Temperature",
+            register_type="holding",
+            address=2,
+            device="circuit_1",
+        ),
+        ModbusRegister(
+            unique_id="room_set_temperature_circuit_1",
+            name="Room Set Temperature",
+            register_type="holding",
+            address=3,
+            device="circuit_1",
+        ),
+        ModbusRegister(
+            unique_id="operating_mode_circuit_1",
+            name="Operating Mode",
+            register_type="holding",
+            address=4,
+            device="circuit_1",
+        ),
+    ]
+
+    circuits = _collect_circuit_registers(registers)
+
+    assert "circuit_1" in circuits
+    assert circuits["circuit_1"]["current_temp"].unique_id == "actual_room_temperature_circuit_1"
+    assert circuits["circuit_1"]["target_temp"].unique_id == "room_set_temperature_circuit_1"
+    assert circuits["circuit_1"]["mode"].unique_id == "operating_mode_circuit_1"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import pytest
+
+from custom_components.keba_heat_pump_modbus.coordinator import KebaCoordinator
+from custom_components.keba_heat_pump_modbus.models import ModbusRegister
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+class DummyClient:
+    def __init__(self, data=None, exc=None):
+        self.data = data or {}
+        self.exc = exc
+
+    def read_all(self, _registers):
+        if self.exc:
+            raise self.exc
+        return self.data
+
+
+class DummyHass:
+    def __init__(self, exc=None):
+        self.exc = exc
+
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        if self.exc:
+            raise self.exc
+        return func(*args, **kwargs)
+
+
+def test_coordinator_updates_data():
+    hass = DummyHass()
+    client = DummyClient({"a": 1})
+    registers = [
+        ModbusRegister(
+            unique_id="a",
+            name="A",
+            register_type="input",
+            address=0,
+        )
+    ]
+    coordinator = KebaCoordinator(hass, client, registers, scan_interval=30)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data == {"a": 1}
+
+
+def test_coordinator_raises_update_failed():
+    hass = DummyHass()
+    client = DummyClient(exc=RuntimeError("boom"))
+    coordinator = KebaCoordinator(hass, client, [], scan_interval=30)
+
+    with pytest.raises(UpdateFailed):
+        asyncio.run(coordinator._async_update_data())


### PR DESCRIPTION
### Motivation

- Enable test coverage reporting by default and increase automated test coverage across the integration.
- Exercise additional edge cases and error paths in the Modbus client, coordinator, and entity code to improve robustness.
- Ensure entity setup and option flows handle missing or malformed data and that client operations validate inputs.

### Description

- Add `pytest.ini` with `--cov=custom_components/keba_heat_pump_modbus --cov-report=term-missing` to enable pytest-cov by default.
- Add new tests `tests/test_coordinator.py` and `tests/test_climate.py` to cover coordinator update/error handling and circuit register collection logic.
- Expand existing test suites (`tests/test_modbus_client.py`, `tests/test_entities.py`, `tests/test_init.py`) with cases covering Modbus connection failures, write scaling/range errors, select value-map validation, water heater/climate edge cases, and unload behavior.

### Testing

- Running `pytest` in this environment initially failed because the `pytest-cov` plugin is not available and the `--cov` option is unrecognized.
- Running `pytest -o addopts=` (which disables the coverage addopts) executed the full test suite and resulted in `37 passed`.
- The added tests exercise `KebaModbusClient` decoding/encoding and write paths, `KebaCoordinator` update failure handling, and multiple entity behaviors, and all automated tests passed when coverage args were disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952e166795483238bad1f33653a3f93)