### PR TITLE
feat: add host/port/unit-id to options flow

### DIFF
--- a/custom_components/keba_heat_pump_modbus/__init__.py
+++ b/custom_components/keba_heat_pump_modbus/__init__.py
@@ -40,9 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up KEBA Heat Pump Modbus from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    host = entry.data[CONF_HOST]
-    port = entry.data[CONF_PORT]
-    unit_id = entry.data[CONF_UNIT_ID]
+    host = entry.options.get(CONF_HOST, entry.data[CONF_HOST])
+    port = entry.options.get(CONF_PORT, entry.data[CONF_PORT])
+    unit_id = entry.options.get(CONF_UNIT_ID, entry.data[CONF_UNIT_ID])
     scan_interval = entry.options.get(
         CONF_SCAN_INTERVAL,
         entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),

--- a/custom_components/keba_heat_pump_modbus/config_flow.py
+++ b/custom_components/keba_heat_pump_modbus/config_flow.py
@@ -92,12 +92,23 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         errors: Dict[str, str] = {}
 
         if user_input is not None:
-            # Only scan interval right now
             return self.async_create_entry(
                 title="",
                 data=user_input,
             )
 
+        current_host = self._entry.options.get(
+            CONF_HOST,
+            self._entry.data.get(CONF_HOST),
+        )
+        current_port = self._entry.options.get(
+            CONF_PORT,
+            self._entry.data.get(CONF_PORT, DEFAULT_PORT),
+        )
+        current_unit_id = self._entry.options.get(
+            CONF_UNIT_ID,
+            self._entry.data.get(CONF_UNIT_ID, DEFAULT_UNIT_ID),
+        )
         current_scan = self._entry.options.get(
             CONF_SCAN_INTERVAL,
             self._entry.data.get(
@@ -114,6 +125,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         data_schema = vol.Schema(
             {
+                vol.Required(CONF_HOST, default=current_host): str,
+                vol.Optional(CONF_PORT, default=current_port): int,
+                vol.Optional(
+                    CONF_UNIT_ID, default=current_unit_id
+                ): int,
                 vol.Required(
                     CONF_SCAN_INTERVAL, default=current_scan
                 ): int,

--- a/custom_components/keba_heat_pump_modbus/strings.json
+++ b/custom_components/keba_heat_pump_modbus/strings.json
@@ -1,4 +1,33 @@
 {
+    "config": {
+        "step": {
+            "user": {
+                "title": "KEBA Heat Pump",
+                "description": "Configure Modbus connection settings for your KEBA heat pump.",
+                "data": {
+                    "host": "IP Address / Hostname",
+                    "port": "Port",
+                    "unit_id": "Modbus Unit ID",
+                    "scan_interval": "Scan interval (seconds)",
+                    "heat_circuits_used": "Number of heating circuits (1\u20134)"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options",
+                "data": {
+                    "host": "IP Address / Hostname",
+                    "port": "Port",
+                    "unit_id": "Modbus Unit ID",
+                    "scan_interval": "Scan interval (seconds)",
+                    "heat_circuits_used": "Number of heating circuits (1\u20134)"
+                }
+            }
+        }
+    },
     "entity": {
         "water_heater": {
             "hot_water_tank": {

--- a/custom_components/keba_heat_pump_modbus/translations/de.json
+++ b/custom_components/keba_heat_pump_modbus/translations/de.json
@@ -19,6 +19,9 @@
             "init": {
                 "title": "Optionen",
                 "data": {
+                    "host": "IP-Adresse / Hostname",
+                    "port": "Port",
+                    "unit_id": "Modbus Unit-ID",
                     "scan_interval": "Aktualisierungsintervall (Sekunden)",
                     "heat_circuits_used": "Anzahl Heizkreise (1\u20134)"
                 }

--- a/custom_components/keba_heat_pump_modbus/translations/en.json
+++ b/custom_components/keba_heat_pump_modbus/translations/en.json
@@ -1,4 +1,33 @@
 {
+    "config": {
+        "step": {
+            "user": {
+                "title": "KEBA Heat Pump",
+                "description": "Configure Modbus connection settings for your KEBA heat pump.",
+                "data": {
+                    "host": "IP Address / Hostname",
+                    "port": "Port",
+                    "unit_id": "Modbus Unit ID",
+                    "scan_interval": "Scan interval (seconds)",
+                    "heat_circuits_used": "Number of heating circuits (1\u20134)"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options",
+                "data": {
+                    "host": "IP Address / Hostname",
+                    "port": "Port",
+                    "unit_id": "Modbus Unit ID",
+                    "scan_interval": "Scan interval (seconds)",
+                    "heat_circuits_used": "Number of heating circuits (1\u20134)"
+                }
+            }
+        }
+    },
     "entity": {
         "water_heater": {
             "hot_water_tank": {


### PR DESCRIPTION
## Summary

Makes Modbus connection parameters (host, port, unit ID) configurable after initial setup via the options flow. Previously, changing e.g. the heat pump IP address required deleting and re-adding the integration.

## Changes

**`config_flow.py`** — Added CONF_HOST, CONF_PORT, CONF_UNIT_ID to the OptionsFlowHandler schema with current values pre-filled from options (falling back to entry data).

**`__init__.py`** — async_setup_entry now reads host/port/unit-id from entry.options first, falling back to entry.data. This ensures options changes are picked up when the entry is reloaded.

**`strings.json`, `translations/en.json`, `translations/de.json`** — Added options flow field labels for host, port, and unit-id.

| File | Change |
|------|--------|
| config_flow.py | +18 lines: options flow host/port/unit-id fields |
| __init__.py | 3 lines: read from options with data fallback |
| strings.json | +29 lines: config + options flow labels |
| translations/en.json | +29 lines: English labels |
| translations/de.json | +3 lines: German options labels |

## Testing

- python -m pytest tests/ -q -o addopts= → 53 passed, 2 failed (pre-existing timer-related failures in test_modbus_client.py, unrelated to this change)

Closes #72