### PR TITLE
feat: support pre-releases in release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,6 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           commitish: main
+          prerelease: ${{ contains(github.ref, '-') }}
 
       - name: Checkout repository
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

Adds pre-release detection to the release-drafter workflow. When a tag with a hyphen suffix is pushed (e.g. `v1.4.0-beta.1`, `v1.4.0-rc.1`), GitHub automatically marks the release as a pre-release. Stable tags (`v1.4.0`) remain full releases.

## Changes

**`.github/workflows/release-drafter.yml`** — 1 insertion

Added `prerelease: ${{ contains(github.ref, '-') }}` to the release-drafter action step. This evaluates the tag name: if it contains a `-` the release is created as pre-release; if not, it is a full release.

| Before | After |
|--------|-------|
| `with:` only `commitish: main` | `with:` `commitish: main` + `prerelease: ${{ contains(github.ref, '-') }}` |

## Testing

- CI config change only — no Python tests to run
- Verification: push a tag like `v1.4.0-beta.1` and confirm the release is marked as "Pre-release" on GitHub

Closes #78